### PR TITLE
Improve mini cards display

### DIFF
--- a/assets/components/molecules/card-deck/card-deck-mini-cards.twig
+++ b/assets/components/molecules/card-deck/card-deck-mini-cards.twig
@@ -17,3 +17,22 @@
   </a>
   {% endfor %}
 </div>
+
+<div class="card-deck mini-cards">
+  {% for i in 1..4 %}
+    <a href="#" class="card link-trapeze-horizontal">
+      {% block image -%}
+      <picture class="card-img-top">
+        <img src="./images/styleguide/minicard_teaser.jpg" class="img-fluid" title="" alt="" />
+      </picture>
+      {% endblock -%}
+      {% block card_body %}
+      <div class="card-body">
+        {% block content %}
+          <h3 class="card-title">{% block title %}Card title{% endblock %}</h3>
+        {% endblock %}
+      </div>
+      {% endblock -%}
+  </a>
+  {% endfor %}
+</div>

--- a/assets/components/molecules/card-deck/card-deck.scss
+++ b/assets/components/molecules/card-deck/card-deck.scss
@@ -217,6 +217,17 @@
   }
 
   &.mini-cards {
+    justify-content: center;
+    
+    @include media-breakpoint-down(xs) {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      
+      > .card {
+        margin: $spacer * 0.5;
+      }
+    }
     
     .deck-title {
       flex-basis: 100%;
@@ -234,18 +245,19 @@
     }
     
     > .card {
-      flex-basis: 47%;
+      flex-basis: calc( 50% - #{$spacer} );
+      flex-grow: 0;
     }
     
     @include media-breakpoint-up(sm) {
       > .card {
-        flex-basis: 30%;
+        flex-basis: calc( 33.3334% - #{$spacer} );
       }
     }
 
     @include media-breakpoint-up(xl) {
       > .card {
-        flex-basis: 14%;
+        flex-basis: calc( 16.6667% - #{$spacer} );
       }
     }
     

--- a/assets/components/molecules/card-deck/card-deck.yml
+++ b/assets/components/molecules/card-deck/card-deck.yml
@@ -3,6 +3,7 @@ name: card-deck
 variants:
   - name: mini-cards
     title: Mini cards
+    notes: When less than 6 mini cards are displayed, the cards are centered in the row.
   - name: duo
     title: Duo
   - name: duo-gray


### PR DESCRIPTION
When there is less than 6 cards in a row, they are still displayed in small size instead of beeing stretched to fit the row's width. Mini cards are centered in the row.

https://epfl-webvolution.atlassian.net/browse/WEBEVOL-34