### PR TITLE
[fix] docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 services:
 
     server:
-      image: kkarczmarczyk/node-yarn:8.0
+      image: node:lts
       container_name: server
       working_dir: /app
       command: bash -c "yarn && yarn start"
@@ -12,7 +12,7 @@ services:
         - "3000:3000"
 
     builder:
-      image: kkarczmarczyk/node-yarn:8.0
+      image: node:lts
       container_name: builder
       working_dir: /app
       command: bash -c "yarn && yarn build"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,18 @@
 version: "3.3"
 services:
-
-    server:
-      image: node:lts
-      container_name: server
-      working_dir: /app
-      command: bash -c "yarn && yarn start"
-      volumes:
-        - .:/app
-      ports:
-        - "3000:3000"
-
-    builder:
-      image: node:lts
-      container_name: builder
-      working_dir: /app
-      command: bash -c "yarn && yarn build"
-      volumes:
-        - .:/app
+  server:
+    image: node:lts
+    container_name: server
+    working_dir: /app
+    command: bash -c "yarn && yarn start"
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+  builder:
+    image: node:lts
+    container_name: builder
+    working_dir: /app
+    command: bash -c "yarn && yarn build"
+    volumes:
+      - .:/app


### PR DESCRIPTION
Now uses the default [node](https://hub.docker.com/_/node/) image which includes yarn by default.
Node is `lts` (v12.18.3)
Yarn is v1.22.4
