### PR TITLE
Remove "overflow: hidden" from .header-light-content on small screens

### DIFF
--- a/assets/components/organisms/header/header.scss
+++ b/assets/components/organisms/header/header.scss
@@ -176,7 +176,7 @@
     @include media-breakpoint-down(lg) {
       height: 100%;
       padding: 0.3rem 0;
-      overflow: hidden;
+      //overflow: hidden;
 
       .logo {
         //order: 1;


### PR DESCRIPTION
La propriété "overflow: hidden" appliquée au div header-light-content sur les écrans en-dessous de 1200px cachait les éléments du menu déroulant des langues. J'ai testé avec et sans cette propriété sous plusieurs navigateurs, et je ne sais honnêtement pas à quoi elle servait.