### PR TITLE
Allow `overflow:visible` on the dropdown component

### DIFF
--- a/assets/config/styleguide.scss
+++ b/assets/config/styleguide.scss
@@ -39,6 +39,13 @@
   overflow: hidden;
 }
 
+/*  Dropdown needs `overflow: visible` to allow it to
+    escape its container. */
+.tlbx-item-preview.tlbx-component-dropdown {
+  overflow: visible;
+}
+
+
 .tlbx-sidebar-item-list {
   margin-left: 0;
   padding: 0;


### PR DESCRIPTION
The dropdown button in the styleguide isn't visible, because its container has `overflow: hidden`.

![2021-04-01_08-28](https://user-images.githubusercontent.com/131808/113253404-7e4b2a80-92c5-11eb-9fb0-2e2478eafaff.png)

The proposed fix allows `overflow:visible` for this specifc component only.

![2021-04-01_08-30](https://user-images.githubusercontent.com/131808/113253469-902ccd80-92c5-11eb-9ee9-2acd232cc397.png)
