### PR TITLE
Actu 2026 - august updates

### DIFF
--- a/assets/components/atoms/collapse/collapse.twig
+++ b/assets/components/atoms/collapse/collapse.twig
@@ -1,14 +1,16 @@
+{% set collapse_title = collapse_title ?: 'On the Origin of Species' %}
+{% set collapse_id = collapse_id ?: 'collapse-1' %}
 <button
   class="collapse-title collapse-title-desktop collapsed"
   type="button"
   data-toggle="collapse"
-  data-target="#collapse-1"
+  data-target="#{{ collapse_id }}"
   aria-expanded="false"
-  aria-controls="collapse-1"
+  aria-controls="{{ collapse_id }}"
 >
-  On the Origin of Species
+  {{ collapse_title }}
 </button>
 
-<div class="collapse collapse-item collapse-item-desktop" id="collapse-1">
+<div class="collapse collapse-item collapse-item-desktop" id="{{ collapse_id }}">
   <p>Book by Charles Darwin, 1859 — On the Origin of Species, published on 24 November 1859, is a work of scientific literature by Charles Darwin which is considered to be the foundation of evolutionary biology.</p>
 </div>

--- a/assets/components/molecules/card/card-news-horizontal.twig
+++ b/assets/components/molecules/card/card-news-horizontal.twig
@@ -7,7 +7,6 @@
   {% block card_body %}
   <div class="card-body pt-4">
     {% block content %}
-    <h6 class="text-small font-weight-bold text-primary mb-1">Santé</h6>
     <h3 class="card-title mb-2">{{ title|default("Une mini-vessie humaine révèle la cause des infections récurrentes") }}</h3>
     <p class="pb-2">{{ body|default("Des scientifiques de l’EPFL, de l’Université de Heidelberg et de Roche ont mis au point une mini-vessie  humaine afin de montrer...") }}</p>
     <time datetime="2018-03-26" class="small mb-0"><span class="sr-only">Publié: </span>{{ pubdate|default('Il y a 2 jours') }}</time>

--- a/assets/components/molecules/collapse-group/collapse-group.twig
+++ b/assets/components/molecules/collapse-group/collapse-group.twig
@@ -3,47 +3,7 @@
 <h4>{{title}}</h4>
 {% endif %}
 
-<button
-  class="collapse-title collapse-title-desktop collapsed"
-  type="button"
-  data-toggle="collapse"
-  data-target="#collapse-1"
-  aria-expanded="false"
-  aria-controls="collapse-1"
->
-  On the Origin of Species
-</button>
+{% include '@atoms/collapse/collapse.twig' with { collapse_title: 'On the Origin of Species', collapse_id: 'collapse-1' } %}
+{% include '@atoms/collapse/collapse.twig' with { collapse_title: 'Silent Spring', collapse_id: 'collapse-2' } %}
+{% include '@atoms/collapse/collapse.twig' with { collapse_title: 'The Hichhiker\'s Guide to the Galaxy', collapse_id: 'collapse-3' } %}
 
-<div class="collapse collapse-item collapse-item-desktop" id="collapse-1">
-  <p>Book by Charles Darwin, 1859 — On the Origin of Species, published on 24 November 1859, is a work of scientific literature by Charles Darwin which is considered to be the foundation of evolutionary biology.</p>
-</div>
-
-<button
-  class="collapse-title collapse-title-desktop collapsed"
-  type="button"
-  data-toggle="collapse"
-  data-target="#collapse-2"
-  aria-expanded="false"
-  aria-controls="collapse-2"
->
-  Silent Spring
-</button>
-
-<div class="collapse collapse-item collapse-item-desktop" id="collapse-2">
-  <p>Book by Rachel Carson, 1962 — Silent Spring is an environmental science book by Rachel Carson. The book was published on 27 September 1962 and it documented the adverse effects on the environment of the indiscriminate use of pesticides.</p>
-</div>
-
-<button
-  class="collapse-title collapse-title-desktop collapsed"
-  type="button"
-  data-toggle="collapse"
-  data-target="#collapse-3"
-  aria-expanded="false"
-  aria-controls="collapse-3"
->
-  The Hitchhiker's Guide to the Galaxy
-</button>
-
-<div class="collapse collapse-item collapse-item-desktop" id="collapse-3">
-  <p>Book by Douglas Adams, 1978–80 — The Hitchhiker's Guide to the Galaxy (sometimes referred to as HG2G, HHGTTG or H2G2) is a comedy science fiction series created by Douglas Adams. Originally a radio comedy broadcast on BBC Radio 4 in 1978, it was later adapted to other formats, including stage shows, novels, comic books, a 1981 TV series, a 1984 video game, and 2005 feature film.</p>
-</div>

--- a/assets/components/organisms/fullwidth-teaser/fullwidth-teaser-simplified-right.twig
+++ b/assets/components/organisms/fullwidth-teaser/fullwidth-teaser-simplified-right.twig
@@ -1,5 +1,3 @@
 {% extends 'fullwidth-teaser-simplified.twig' %}
 
 {% block position_class %}fullwidth-teaser-right{% endblock %}
-
-{% block title_tag %}<h6 class="text-small font-weight-bold text-primary mb-1">Santé</h6>{% endblock %}

--- a/assets/components/pages/news-detail-2026/news-detail-2026.twig
+++ b/assets/components/pages/news-detail-2026/news-detail-2026.twig
@@ -100,9 +100,9 @@
         <a href="#" class="tag tag-primary mt-2 mr-1">Laboratoire de biophysique statistique (LBS)</a>
       </div>
 
-      {% include '@molecules/collapse-group/collapse-group.twig' with {
-        title: null
-      } %}
+      {% include '@atoms/collapse/collapse.twig' with { collapse_title: 'Financement', collapse_id: 'collapse-1' } %}
+      {% include '@atoms/collapse/collapse.twig' with { collapse_title: 'Références', collapse_id: 'collapse-2' } %}
+
 
       <footer class="my-4 d-md-flex justify-content-between border-0">
         <div>
@@ -111,10 +111,6 @@
             <small itemprop="author publisher" itemscope="" itemtype="https://schema.org/Person">
               <a href="#" class="opacity-80"><span itemprop="name">Nik Papageorgiou</span></a>
             </small>
-          </p>
-          <p class="small text-muted mb-0 mt-1">
-            <strong>Source:</strong>
-            <a href="/search/mediacom/fr" class="opacity-80">EPFL</a>
           </p>
         </div>
 


### PR DESCRIPTION
- removed "Source" in news details
- removed Themes in Card News and Fullwidth Teaser
- added variables to collapse/collapse.twig
- updated molecules/collapse-group
- changed collapse titles in news-detail-2026