### PR TITLE
[feature] Link version number to release page

### DIFF
--- a/reader/components/Sidebar/Sidebar.jsx
+++ b/reader/components/Sidebar/Sidebar.jsx
@@ -27,7 +27,11 @@ export default function Sidebar({ location }) {
           Toolbox <span>Design System</span>
         </h1>
       )}
-      <h3 className="tlbx-sidebar-version">Version {packageJSON.version}</h3>
+      <h3 className="tlbx-sidebar-version">
+        <a href={`https://github.com/epfl-si/elements/releases/tag/${packageJSON.version}`} target="_blank" rel="noreferrer">
+          Version {packageJSON.version}
+        </a>
+      </h3>
 
       <ul className="tlbx-sidebar-item-list">
         <li>
@@ -56,4 +60,3 @@ export default function Sidebar({ location }) {
 Sidebar.propTypes = {
   location: PropTypes.object.isRequired,
 }
-

--- a/reader/components/Sidebar/Sidebar.scss
+++ b/reader/components/Sidebar/Sidebar.scss
@@ -12,6 +12,20 @@
   @media only screen and (max-width: 767px) {
     margin-bottom: 3rem;
   }
+
+  .tlbx-sidebar-version {
+    margin: 0.5rem 1rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.8rem;
+    font-weight: 200;
+
+    a {
+      &:hover {
+        color: #a8404a; // $link-hover-color?
+      }
+    }
+
+  }
 }
 
 .tlbx-sidebar-title {
@@ -22,11 +36,4 @@
   span {
     font-weight: 200;
   }
-}
-
-.tlbx-sidebar-version {
-  margin: 0.5rem 1rem;
-  margin-bottom: 1.5rem;
-  font-size: 0.8rem;
-  font-weight: 200;
 }


### PR DESCRIPTION
Make the displayed version number a subtle link to the corresponding release,
allowing users to quickly access release notes without adding visual clutter.